### PR TITLE
Fixes issue where escape char in M1 command would get lost in Markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ One (long) line of code:
 ```
 
 ## New bash command line for M1 Macs
-please change the command line in Alfred to the following for M1 macs - "/opt/homebrew/Cellar/speedtest-cli/$(ls /opt/homebrew/Cellar/speedtest-cli | grep "." | sort -V -r | head -n 1)/bin/speedtest | grep "Download\|Upload"
+
+Please change the command line in Alfred to the following for M1 macs:
+
+```bash
+"/opt/homebrew/Cellar/speedtest-cli/$(ls /opt/homebrew/Cellar/speedtest-cli | grep "." | sort -V -r | head -n 1)/bin/speedtest | grep "Download\|Upload"
+```
 
 ## Discussion
 


### PR DESCRIPTION
Currently the text for the updated M1 command is being rendered as 

```
"/opt/homebrew/Cellar/speedtest-cli/$(ls /opt/homebrew/Cellar/speedtest-cli | grep "." | sort -V -r | head -n 1)/bin/speedtest | grep "Download|Upload"
```

Where `"Download|Upload"` is missing a crucial `\`. This results in no notification after the first "Please wait 30 seconds...". 


Image of rendered text below 👇

<img width="869" alt="image" src="https://user-images.githubusercontent.com/5825210/159109072-1cb67979-881b-4ab4-a244-e396e1ce7ab7.png">
